### PR TITLE
Fix for grid mobile devices

### DIFF
--- a/hotdog/BaseTest.py
+++ b/hotdog/BaseTest.py
@@ -194,13 +194,18 @@ class HotDogBaseTest(unittest.TestCase):
         browser_profile = None
 
         if 'grid' in provider:
-            # if self.desired_caps['browserName'].lower() == 'firefox':
-            #     browser_profile = seleniumWebdriver.FirefoxProfile('/home/matt/l7539ezh.GridTest')
-            if dc['platform'].lower() == 'windows':
-                dc['marionette'] = False
-            if dc['browserName'] == 'internet explorer':
-                # Will clear the cache, cookies, history, and saved form data for all running instances of Internet Explorer
-                builtins.threadlocal.config['desiredCaps']["ie.ensureCleanSession"] = True
+            # Added try/except - if running mobile 'platform' wont be set. Variable is instead platformName.
+            # try/except allows mobile to run without issue - C.W.
+            try:
+                # if self.desired_caps['browserName'].lower() == 'firefox':
+                #     browser_profile = seleniumWebdriver.FirefoxProfile('/home/matt/l7539ezh.GridTest')
+                if dc['platform'].lower() == 'windows':
+                    dc['marionette'] = False
+                if dc['browserName'] == 'internet explorer':
+                    # Will clear the cache, cookies, history, and saved form data for all running instances of Internet Explorer
+                    builtins.threadlocal.config['desiredCaps']["ie.ensureCleanSession"] = True
+            except:
+                pass
             url = cls.GRID_URL
         elif 'sauce' in provider:
             url = cls.SAUCE_URL


### PR DESCRIPTION
Added try/except - if running mobile 'platform' wont be set in desired capabilities, so  select_driver method will fail on KeyError. Capability for mobile device on grid is set to 'platformName' by default instead of 'platform'.